### PR TITLE
feat: HTTPStatusError.Header + bounded auth body reads

### DIFF
--- a/http/auth_retry.go
+++ b/http/auth_retry.go
@@ -115,7 +115,7 @@ func DoWithAuthRetry(
 
 		switch resp.StatusCode {
 		case http.StatusUnauthorized: // 401
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, MaxErrorBodySize))
 			resp.Body.Close()
 			wwa := resp.Header.Get("Www-Authenticate")
 			msg := strings.TrimSpace(string(body))
@@ -131,7 +131,7 @@ func DoWithAuthRetry(
 			continue
 
 		case http.StatusForbidden: // 403
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, MaxErrorBodySize))
 			resp.Body.Close()
 			wwa := resp.Header.Get("Www-Authenticate")
 			msg := strings.TrimSpace(string(body))

--- a/http/auth_retry_test.go
+++ b/http/auth_retry_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -280,5 +281,61 @@ func TestDoWithAuthRetry_NilConfig(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected error for 401 with nil config")
+	}
+}
+
+// TestDoWithAuthRetry_401BodyTruncatedAtMaxErrorBodySize verifies that 401
+// error response bodies exceeding MaxErrorBodySize are truncated to prevent
+// memory exhaustion from malicious or misconfigured servers returning oversized
+// error payloads.
+func TestDoWithAuthRetry_401BodyTruncatedAtMaxErrorBodySize(t *testing.T) {
+	largeBody := bytes.Repeat([]byte("x"), int(MaxErrorBodySize)*4)
+
+	_, err := DoWithAuthRetry(nil,
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", "http://example.com", nil)
+		},
+		func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 401,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewReader(largeBody)),
+			}, nil
+		},
+	)
+
+	var authErr *AuthRetryError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthRetryError, got %T: %v", err, err)
+	}
+	if len(authErr.Message) > int(MaxErrorBodySize) {
+		t.Errorf("body length = %d, want <= %d (MaxErrorBodySize)", len(authErr.Message), MaxErrorBodySize)
+	}
+}
+
+// TestDoWithAuthRetry_403BodyTruncatedAtMaxErrorBodySize verifies that 403
+// error response bodies are also subject to the MaxErrorBodySize cap.
+func TestDoWithAuthRetry_403BodyTruncatedAtMaxErrorBodySize(t *testing.T) {
+	largeBody := bytes.Repeat([]byte("y"), int(MaxErrorBodySize)*4)
+
+	_, err := DoWithAuthRetry(nil,
+		func() (*http.Request, error) {
+			return http.NewRequest("GET", "http://example.com", nil)
+		},
+		func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 403,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewReader(largeBody)),
+			}, nil
+		},
+	)
+
+	var authErr *AuthRetryError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthRetryError, got %T: %v", err, err)
+	}
+	if len(authErr.Message) > int(MaxErrorBodySize) {
+		t.Errorf("body length = %d, want <= %d (MaxErrorBodySize)", len(authErr.Message), MaxErrorBodySize)
 	}
 }

--- a/http/status.go
+++ b/http/status.go
@@ -1,12 +1,23 @@
 package http
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
+
+// MaxErrorBodySize is the maximum number of bytes read from an HTTP error
+// response body. Prevents memory exhaustion from malicious or misconfigured
+// servers returning oversized error payloads. Shared by DoWithAuthRetry and
+// any other error-body readers in this package.
+const MaxErrorBodySize = 16 << 10 // 16 KB
 
 // HTTPStatusError represents an HTTP response with a non-2xx status code.
-// It captures the status code and response body for error reporting and
-// classification (e.g., 5xx errors are typically transient/retriable).
+// It captures the status code, response headers, and response body for error
+// reporting, classification (e.g., 5xx errors are typically transient/retriable),
+// and programmatic inspection (e.g., reading WWW-Authenticate or Retry-After).
 type HTTPStatusError struct {
 	StatusCode int
+	Header     http.Header
 	Body       string
 }
 

--- a/http/status_test.go
+++ b/http/status_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 )
 
@@ -67,5 +69,41 @@ func TestHTTPStatusError_IsTransient(t *testing.T) {
 	err4xx := &HTTPStatusError{StatusCode: 404}
 	if IsHTTPTransient(err4xx.StatusCode) {
 		t.Error("404 should not be transient")
+	}
+}
+
+// TestHTTPStatusError_HeaderAccessible verifies that the Header field on
+// HTTPStatusError is populated and accessible via errors.As. This is important
+// for callers that need to inspect response headers (e.g., Retry-After,
+// X-Request-Id) from non-2xx error responses for diagnostics or retry logic.
+func TestHTTPStatusError_HeaderAccessible(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Request-Id", "abc123")
+	h.Set("Retry-After", "5")
+
+	err := error(&HTTPStatusError{
+		StatusCode: 503,
+		Header:     h,
+		Body:       "service unavailable",
+	})
+
+	var target *HTTPStatusError
+	if !errors.As(err, &target) {
+		t.Fatal("errors.As failed to match HTTPStatusError")
+	}
+	if got := target.Header.Get("X-Request-Id"); got != "abc123" {
+		t.Errorf("Header X-Request-Id = %q, want %q", got, "abc123")
+	}
+	if got := target.Header.Get("Retry-After"); got != "5" {
+		t.Errorf("Header Retry-After = %q, want %q", got, "5")
+	}
+}
+
+// TestMaxErrorBodySize_Value verifies the MaxErrorBodySize constant is 16 KB.
+// This constant caps error response body reads to prevent memory exhaustion
+// from oversized error payloads.
+func TestMaxErrorBodySize_Value(t *testing.T) {
+	if MaxErrorBodySize != 16*1024 {
+		t.Errorf("MaxErrorBodySize = %d, want %d", MaxErrorBodySize, 16*1024)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `Header http.Header` field to `HTTPStatusError` so callers can inspect response headers (e.g., `Retry-After`, `WWW-Authenticate`, `X-Request-Id`) from non-2xx error responses
- Add `MaxErrorBodySize` constant (16 KB) — shared cap for error response body reads
- Bound `io.ReadAll` calls in `DoWithAuthRetry` to `MaxErrorBodySize` to prevent memory exhaustion from oversized 401/403 response payloads

## Motivation
MCPKit type-aliases `HTTPStatusError` from servicekit. Issue [mcpkit#134](https://github.com/panyam/mcpkit/issues/134) needs HTTP headers exposed in client connection errors. The struct change must happen here since mcpkit uses a type alias.

The unbounded `io.ReadAll` in `DoWithAuthRetry` (lines 118, 134) is a latent DoS vector — a malicious server returning a large 401/403 body would be fully read into memory.

## Test plan
- [x] `TestHTTPStatusError_HeaderAccessible` — Header field accessible via `errors.As`
- [x] `TestMaxErrorBodySize_Value` — constant is 16 KB
- [x] `TestDoWithAuthRetry_401BodyTruncatedAtMaxErrorBodySize` — 401 body capped at 16 KB
- [x] `TestDoWithAuthRetry_403BodyTruncatedAtMaxErrorBodySize` — 403 body capped at 16 KB
- [x] All existing tests pass (pre-push hook verified)