### PR TITLE
build: add coverage Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ node_modules/
 # Temporary files
 thoughts
 *.log
+
+# Coverage artifacts
+*.out
+coverage.html
+test-reports/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: test test-race vet install-hooks
+.PHONY: test test-race vet cover cover-html cover-func testall install-hooks
+
+REPORT_DIR := test-reports
 
 test:
 	go test ./...
@@ -9,6 +11,25 @@ test-race:
 
 vet:
 	go vet ./...
+
+cover: ## Run tests with coverage summary
+	go test -cover ./... -count=1 -timeout 60s
+
+cover-html: ## Run tests with coverage and generate HTML report
+	@mkdir -p $(REPORT_DIR)
+	go test -coverprofile=$(REPORT_DIR)/coverage.out ./... -count=1 -timeout 60s
+	go tool cover -html=$(REPORT_DIR)/coverage.out -o $(REPORT_DIR)/coverage.html
+	@echo "Coverage report: $(REPORT_DIR)/coverage.html"
+
+cover-func: ## Show per-function coverage sorted by lowest (top 30)
+	@mkdir -p $(REPORT_DIR)
+	go test -coverprofile=$(REPORT_DIR)/coverage.out ./... -count=1 -timeout 60s
+	go tool cover -func=$(REPORT_DIR)/coverage.out | sort -k3 -n | head -30
+
+testall: vet cover-html test-race ## Run full test suite: vet + coverage + race detection
+	@echo ""
+	@echo "=== servicekit testall complete ==="
+	@echo "Coverage report: $(REPORT_DIR)/coverage.html"
 
 install-hooks:
 	@if [ -f .git ]; then \


### PR DESCRIPTION
New targets: \`cover\`, \`cover-html\`, \`cover-func\`. Also adds \`*.out\`, \`coverage.html\`, \`test-reports/\` to .gitignore.

Current coverage snapshot:
- grpcws: 75.7%
- http: 65.1%
- middleware: 90.8%

Sibling PRs in [mcpkit](https://github.com/panyam/mcpkit/pull/204) and [oneauth](https://github.com/panyam/oneauth/pull/new/chore/coverage-targets).