### PR TITLE
feat(http)!: redesign Call with generics, options, and secure TLS (#28)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,3 +85,67 @@ func (h *MyHandler) Validate(w http.ResponseWriter, r *http.Request) (*MyConn, b
 - **Upgrade to typed** if: you have well-defined request/response types, want IDE autocomplete, or want the compiler to catch type mismatches
 
 The wire format is identical — both use JSON text frames. Clients don't need to change.
+
+## http.Call: generic signature, options, secure TLS default (issue #28)
+
+`http.Call` was reworked to address five gaps: no context propagation, no typed destination, 204 No Content failed, error body/headers were lost, and TLS verification was disabled on the default clients. This is a breaking change.
+
+### Signature change
+
+Before:
+```go
+func Call(req *http.Request, client *http.Client) (any, error)
+```
+
+After:
+```go
+func Call[T any](ctx context.Context, req *http.Request, opts ...CallOption) (T, error)
+func CallVoid(ctx context.Context, req *http.Request, opts ...CallOption) error
+```
+
+- `ctx` is explicit — cancel mid-call by canceling the context.
+- `T` is the decoded type. No more `any` round-trip-via-map.
+- `CallVoid` for endpoints whose response body you don't need (DELETE 204, ack-style POST).
+- Empty 2xx bodies (204 No Content) now succeed: `Call[T]` returns the zero value, `CallVoid` returns nil.
+
+### Call-site migration
+
+| Use | Before | After |
+|---|---|---|
+| Typed JSON response | `r, err := Call(req, c)` then re-decode | `u, err := Call[User](ctx, req, WithClient(c))` |
+| Map/dynamic response | `r, err := Call(req, c)` | `m, err := Call[map[string]any](ctx, req, WithClient(c))` |
+| 204 / void response | (errored) | `err := CallVoid(ctx, req)` |
+| Custom client | second positional arg | `Call[T](ctx, req, WithClient(c))` |
+
+### HTTPError now preserves body and headers
+
+Before:
+```go
+type HTTPError struct {
+    Code    int
+    Message string
+}
+```
+
+After:
+```go
+type HTTPError struct {
+    Code   int
+    Body   []byte       // raw response body
+    Header http.Header  // response headers (Retry-After, rate-limit, etc.)
+}
+```
+
+If you previously read `Message`, switch to `string(err.Body)`. `HTTPErrorCode(err)` is unchanged.
+
+### TLS default flipped to secure
+
+`DefaultHttpClient`, `LowQPSHttpClient`, `MediumQPSHttpClient`, and `HighQPSHttpClient` no longer set `InsecureSkipVerify: true`. Calls to public APIs now verify certificates by default.
+
+For internal endpoints with self-signed certificates, use `WithInsecureTLS()`:
+
+```go
+data, err := Call[Response](ctx, req, WithInsecureTLS())
+```
+
+Or pass a custom `*http.Client` whose transport you control via `WithClient`.

--- a/http/caller.go
+++ b/http/caller.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -9,95 +10,177 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	gut "github.com/panyam/goutils/utils"
 )
 
-/*
-const (
-ErrCodeInvalidRequest     = 400
-ErrCodeInvalidCredentials = 401
-ErrCodeAuthorized         = 403
-ErrCodeEntityNotFound     = 404
+// Default HTTP clients with TLS verification enabled. Suitable for calls to
+// public APIs or any endpoint with a trusted certificate.
+//
+// For internal endpoints with self-signed certificates, either pass a custom
+// *http.Client via WithClient or use the WithInsecureTLS option on Call/CallVoid.
+var (
+	DefaultHttpClient   *http.Client
+	LowQPSHttpClient    *http.Client
+	MediumQPSHttpClient *http.Client
+	HighQPSHttpClient   *http.Client
 )
-*/
 
-var DefaultHttpClient *http.Client
-var LowQPSHttpClient *http.Client
-var MediumQPSHttpClient *http.Client
-var HighQPSHttpClient *http.Client
+// insecureDefaultHttpClient is the shared client used by WithInsecureTLS.
+// Lazily initialized to avoid paying for a tls.Config when no caller asks for it.
+var (
+	insecureDefaultHttpClient     *http.Client
+	insecureDefaultHttpClientOnce sync.Once
+)
 
 func init() {
-	defaultTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-	}
 	DefaultHttpClient = &http.Client{
 		Timeout:   10 * time.Second,
-		Transport: defaultTransport,
-	}
-
-	lowQPSTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-		MaxIdleConns:        10,
-		MaxIdleConnsPerHost: 5,
+		Transport: &http.Transport{},
 	}
 	LowQPSHttpClient = &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: lowQPSTransport,
-	}
-
-	mediumQPSTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 5,
 		},
-		MaxIdleConns:        20,
-		MaxIdleConnsPerHost: 10,
 	}
 	MediumQPSHttpClient = &http.Client{
-		Timeout:   20 * time.Second,
-		Transport: mediumQPSTransport,
-	}
-
-	highQPSTransport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
+		Timeout: 20 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        20,
+			MaxIdleConnsPerHost: 10,
 		},
-		MaxIdleConns:        40,
-		MaxIdleConnsPerHost: 20,
 	}
 	HighQPSHttpClient = &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: highQPSTransport,
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        40,
+			MaxIdleConnsPerHost: 20,
+		},
 	}
+}
+
+func getInsecureDefaultHttpClient() *http.Client {
+	insecureDefaultHttpClientOnce.Do(func() {
+		insecureDefaultHttpClient = &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	})
+	return insecureDefaultHttpClient
+}
+
+// HTTPError is returned for non-2xx responses. Body and Header preserve the
+// raw response for callers that need to parse structured error payloads or
+// inspect headers like Retry-After.
+type HTTPError struct {
+	Code   int
+	Body   []byte
+	Header http.Header
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("Status: %d, Body: %s", e.Code, string(e.Body))
 }
 
 func HTTPErrorCode(err error) int {
 	if err != nil {
-		switch e := err.(type) {
-		case *HTTPError:
+		if e, ok := err.(*HTTPError); ok {
 			return e.Code
-		default:
 		}
 	}
 	return -1
 }
 
-// Representing HTTP specific errors
-type HTTPError struct {
-	Code    int
-	Message string
+// CallOption customizes a Call or CallVoid invocation.
+type CallOption func(*callConfig)
+
+type callConfig struct {
+	client *http.Client
 }
 
-func (t *HTTPError) Error() string {
-	return fmt.Sprintf("Status: %d, Message: %s", t.Code, t.Message)
+// WithClient overrides the *http.Client used to perform the request.
+// If unset, DefaultHttpClient is used.
+func WithClient(c *http.Client) CallOption {
+	return func(cfg *callConfig) { cfg.client = c }
 }
 
-// Creates a URL on a host, path and with optional query parameters
+// WithInsecureTLS uses a package-shared client whose Transport has
+// InsecureSkipVerify=true. Useful for internal endpoints with self-signed
+// certificates. Mutually exclusive with WithClient — last option wins.
+func WithInsecureTLS() CallOption {
+	return func(cfg *callConfig) { cfg.client = getInsecureDefaultHttpClient() }
+}
+
+// Call performs req, reads the entire response body, and JSON-decodes it into T.
+//
+// Contract: this helper is for request/response endpoints whose body fits in
+// memory (JSON APIs, typed CRUD). For streaming/large bodies use client.Do
+// directly; for SSE see SSEReader.
+//
+// Non-2xx responses return a zero T and *HTTPError carrying the status,
+// raw body, and response headers. Empty bodies on 2xx return a zero T with
+// no error (handles 204 No Content).
+func Call[T any](ctx context.Context, req *http.Request, opts ...CallOption) (T, error) {
+	var zero T
+	body, _, err := doCall(ctx, req, opts)
+	if err != nil {
+		return zero, err
+	}
+	if len(body) == 0 {
+		return zero, nil
+	}
+	var out T
+	if err := json.Unmarshal(body, &out); err != nil {
+		return zero, err
+	}
+	return out, nil
+}
+
+// CallVoid performs req and discards the response body. Use for endpoints
+// where the body is not needed (DELETE, ack-style POST). Non-2xx still
+// produces an *HTTPError with body and headers preserved.
+func CallVoid(ctx context.Context, req *http.Request, opts ...CallOption) error {
+	_, _, err := doCall(ctx, req, opts)
+	return err
+}
+
+func doCall(ctx context.Context, req *http.Request, opts []CallOption) ([]byte, *http.Response, error) {
+	cfg := callConfig{client: DefaultHttpClient}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.client == nil {
+		cfg.client = DefaultHttpClient
+	}
+
+	req = req.WithContext(ctx)
+	resp, err := cfg.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, resp, &HTTPError{
+			Code:   resp.StatusCode,
+			Body:   body,
+			Header: resp.Header.Clone(),
+		}
+	}
+	return body, resp, nil
+}
+
+// MakeUrl creates a URL from host, path, and optional pre-encoded query args.
 func MakeUrl(host, path string, args string) (url string) {
 	path = strings.TrimPrefix(path, "/")
 	url = fmt.Sprintf("%s/%s", host, path)
@@ -107,18 +190,16 @@ func MakeUrl(host, path string, args string) (url string) {
 	return url
 }
 
-// Creates a new http request with the given method, endpoint and a bodyready that provides
-// the content the request body.
+// NewRequest builds an http.Request with Content-Type: application/json.
 func NewRequest(method string, endpoint string, bodyReader io.Reader) (req *http.Request, err error) {
-	url := endpoint // t.MakeUrl(endpoint, "")
-	req, err = http.NewRequest(method, url, bodyReader)
+	req, err = http.NewRequest(method, endpoint, bodyReader)
 	if err == nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	return
 }
 
-// Wraps the NewRequest helper to create a request with the payload marshalled as JSON.
+// NewJsonRequest marshals body as JSON and wraps NewRequest.
 func NewJsonRequest(method string, endpoint string, body map[string]any) (req *http.Request, err error) {
 	var bodyBytes []byte
 	if body != nil {
@@ -130,7 +211,7 @@ func NewJsonRequest(method string, endpoint string, body map[string]any) (req *h
 	return NewBytesRequest(method, endpoint, bodyBytes)
 }
 
-// Wraps the NewRequest helper to create request to set the body from a byte array.
+// NewBytesRequest wraps NewRequest with a byte-slice body.
 func NewBytesRequest(method string, endpoint string, body []byte) (req *http.Request, err error) {
 	var bodyReader io.Reader
 	if body != nil {
@@ -139,42 +220,11 @@ func NewBytesRequest(method string, endpoint string, body []byte) (req *http.Req
 	return NewRequest(method, endpoint, bodyReader)
 }
 
-// Makes a http with the tiven request and the http client.  This is a wrapper over the
-// standard library caller that creates a Client (if not provided), performs the request
-// reads the entire body adn optionally converts the payload to an appropriate type
-// based on the response' Content-Type header (for now only application/json is supported.
-func Call(req *http.Request, client *http.Client) (response any, err error) {
-	if client == nil {
-		client = DefaultHttpClient
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Println("client: error making http request: ", err)
-		return nil, err
-	}
-	respbody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode >= 400 {
-		return nil, &HTTPError{resp.StatusCode, string(respbody)}
-	}
-
-	content_type := resp.Header.Get("Content-Type")
-	if strings.HasPrefix(content_type, "application/json") {
-		err = json.Unmarshal(respbody, &response)
-	} else {
-		// send as is
-		response = respbody
-	}
-	return response, err
-}
-
-// A simple wrapper for performing JSON Get requests.
-// The url is the full url once all query params have been added.
-// The onReq callback allows customization of the http requests before it is sent.
+// JsonGet performs a GET and decodes the body via gut.JsonDecodeBytes.
+// onReq, if non-nil, is invoked to customize the request before sending.
+//
+// Prefer Call[T] for typed responses; JsonGet remains for callers that
+// want the raw response alongside the decoded body.
 func JsonGet(url string, onReq func(req *http.Request)) (any, *http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -189,14 +239,11 @@ func JsonGet(url string, onReq func(req *http.Request)) (any, *http.Response, er
 		return nil, resp, err
 	}
 	defer resp.Body.Close()
-	var result any
-	var body []byte
-	body, err = io.ReadAll(resp.Body)
-	// err = json.NewDecoder(resp.Body).Decode(&result)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("Error reading body: ", string(body), err)
 	}
-	result, err = gut.JsonDecodeBytes(body)
+	result, err := gut.JsonDecodeBytes(body)
 	if err != nil {
 		log.Println("Error decoding json: ", string(body), err)
 	}

--- a/http/caller_test.go
+++ b/http/caller_test.go
@@ -1,0 +1,240 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type callTestUser struct {
+	Name string `json:"name"`
+	Age  int    `json:"age"`
+}
+
+func newJSONServer(t *testing.T, status int, body string, headers map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		if _, ok := headers["Content-Type"]; !ok && body != "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestCall_TypedDest(t *testing.T) {
+	srv := newJSONServer(t, 200, `{"name":"alice","age":30}`, nil)
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	got, err := Call[callTestUser](context.Background(), req)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got.Name != "alice" || got.Age != 30 {
+		t.Errorf("decoded = %+v, want {alice 30}", got)
+	}
+}
+
+func TestCall_MapDest(t *testing.T) {
+	srv := newJSONServer(t, 200, `{"name":"bob","age":42}`, nil)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	got, err := Call[map[string]any](context.Background(), req)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got["name"] != "bob" {
+		t.Errorf("got[name] = %v, want bob", got["name"])
+	}
+	// JSON numbers decode as float64 into any
+	if got["age"].(float64) != 42 {
+		t.Errorf("got[age] = %v, want 42", got["age"])
+	}
+}
+
+func TestCallVoid_204NoContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("DELETE", srv.URL, nil)
+	if err := CallVoid(context.Background(), req); err != nil {
+		t.Fatalf("CallVoid: %v", err)
+	}
+}
+
+func TestCall_204ReturnsZeroValue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("DELETE", srv.URL, nil)
+	got, err := Call[callTestUser](context.Background(), req)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got != (callTestUser{}) {
+		t.Errorf("got = %+v, want zero value", got)
+	}
+}
+
+func TestCall_EmptyBodyOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	if err := CallVoid(context.Background(), req); err != nil {
+		t.Fatalf("CallVoid: %v", err)
+	}
+}
+
+func TestCall_ContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	_, err := Call[callTestUser](ctx, req)
+	if err == nil {
+		t.Fatal("expected error from cancel, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestHTTPError_BodyAndHeader(t *testing.T) {
+	srv := newJSONServer(t, 429, `[{"error":"rate limited"}]`, map[string]string{
+		"Retry-After": "30",
+		"X-RateLimit": "1000",
+	})
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, nil)
+	_, err := Call[callTestUser](context.Background(), req)
+	if err == nil {
+		t.Fatal("expected HTTPError, got nil")
+	}
+	herr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("err type = %T, want *HTTPError", err)
+	}
+	if herr.Code != 429 {
+		t.Errorf("Code = %d, want 429", herr.Code)
+	}
+	if string(herr.Body) != `[{"error":"rate limited"}]` {
+		t.Errorf("Body = %q, want raw JSON array", string(herr.Body))
+	}
+	if got := herr.Header.Get("Retry-After"); got != "30" {
+		t.Errorf("Retry-After = %q, want 30", got)
+	}
+	if got := herr.Header.Get("X-RateLimit"); got != "1000" {
+		t.Errorf("X-RateLimit = %q, want 1000", got)
+	}
+}
+
+func TestHTTPError_ErrorString(t *testing.T) {
+	herr := &HTTPError{
+		Code: 500,
+		Body: []byte("internal boom"),
+	}
+	s := herr.Error()
+	if !strings.Contains(s, "500") {
+		t.Errorf("Error() = %q, missing status", s)
+	}
+	if !strings.Contains(s, "internal boom") {
+		t.Errorf("Error() = %q, missing body", s)
+	}
+}
+
+func TestHTTPErrorCode_Unchanged(t *testing.T) {
+	if got := HTTPErrorCode(&HTTPError{Code: 404}); got != 404 {
+		t.Errorf("HTTPErrorCode = %d, want 404", got)
+	}
+	if got := HTTPErrorCode(errors.New("plain")); got != -1 {
+		t.Errorf("HTTPErrorCode plain = %d, want -1", got)
+	}
+}
+
+func TestDefaultHttpClient_VerifiesTLS(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	_, err := Call[map[string]any](context.Background(), req)
+	if err == nil {
+		t.Fatal("expected TLS verification failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
+		t.Errorf("err = %v, expected x509/certificate error", err)
+	}
+}
+
+func TestCall_WithInsecureTLS(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	got, err := Call[map[string]any](context.Background(), req, WithInsecureTLS())
+	if err != nil {
+		t.Fatalf("Call WithInsecureTLS: %v", err)
+	}
+	if got["ok"] != true {
+		t.Errorf("got = %v, want ok=true", got)
+	}
+}
+
+func TestCall_WithClient(t *testing.T) {
+	srv := newJSONServer(t, 200, `{"name":"x","age":1}`, nil)
+	defer srv.Close()
+
+	calls := 0
+	custom := &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			return http.DefaultTransport.RoundTrip(r)
+		}),
+	}
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	_, err := Call[callTestUser](context.Background(), req, WithClient(custom))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("custom client used %d times, want 1", calls)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/http/ping.go
+++ b/http/ping.go
@@ -75,7 +75,7 @@ func (u *URLWaiter) Run() (success bool, iter int, err error) {
 			log.Println("error creating request: ", err)
 			return false, iter, err
 		}
-		resp, err = Call(req, urlPingHttpClient)
+		resp, err = Call[any](req.Context(), req, WithClient(urlPingHttpClient))
 		if err != nil {
 			log.Println("Error calling URl: ", u.Url, err)
 		} else {


### PR DESCRIPTION
## What changes

Closes #28. Reworks `http.Call` end-to-end to fix the five gaps called out in the issue. The helper now exposes a generic, context-aware, option-based API with a typed companion `CallVoid` for endpoints that return no body. `HTTPError` carries the raw response body and headers so callers can parse structured errors or read `Retry-After` without re-issuing the request. Default HTTP clients now verify TLS certificates; per-call opt-out via `WithInsecureTLS()`.

## Reviewer's guide

Read in this order:

1. [http/caller.go](https://github.com/panyam/servicekit/pull/29/files#diff-bbedcb52c4f1f42501eb35206ce47720def13cb5b2695e74dd8aa71489af73ec) — start here. New surface: `Call[T]`, `CallVoid`, `CallOption` (`WithClient`, `WithInsecureTLS`), redesigned `HTTPError{Code, Body, Header}`, and `init()` no longer setting `InsecureSkipVerify`. The shared `doCall` helper performs the request, reads the full body, and centralizes the 2xx/non-2xx branch.
2. [http/caller_test.go](https://github.com/panyam/servicekit/pull/29/files#diff-f928865146a47982bfe74ace570a68db2f3192b12e3301e74d4ee90d16b03c6f) — acceptance. One test per gap plus regression coverage: typed dest, map dest, 204 (both `Call[T]` zero value and `CallVoid`), context cancel, `HTTPError` body+header preservation, secure TLS default vs. `WithInsecureTLS`, custom client routing.
3. [http/ping.go](https://github.com/panyam/servicekit/pull/29/files#diff-100e6203d8c0b5af1ed856335b0e63fd522c8cc55faf23f3e7b812703bfef0dd) — single mechanical update: the one internal caller migrated from `Call(req, client)` to `Call[any](req.Context(), req, WithClient(client))`.
4. [UPGRADING.md](https://github.com/panyam/servicekit/pull/29/files#diff-f411a5009131db5a6c7242b49ca78488f2d274ef9e5e5f4de9262a42108a5386) — migration table for downstream consumers.

Skim: there are no generated files or fixtures in this PR.

## Diff groups

- Production: `http/caller.go`, `http/ping.go`
- Tests: `http/caller_test.go`
- Docs: `UPGRADING.md`

## Decision log

- **Generics over an `any` `dest` parameter.** Initial sketch was `Call(ctx, req, client, dest any) error`. Generics give compile-time type safety and a cleaner call site, at the cost of needing a companion `CallVoid` for the type-param-less void case. Two narrow functions beat a sentinel `[struct{}]` discard.
- **Options pattern over `Insecure*HttpClient` parallel variables.** A `WithInsecureTLS()` option backed by a single lazy package-private client is enough; building a parallel `Insecure{Default,LowQPS,MediumQPS,HighQPS}HttpClient` set would have proliferated names for a niche escape hatch. Callers who need both pool-tuned *and* insecure transports can construct one and pass via `WithClient`.
- **`HTTPError.Message` dropped, replaced by `Body []byte`.** The old field was just `string(body)`; `Body` is strictly more useful and `Error()` renders the same human-readable form. Headers preserved via `Header.Clone()` so callers can read `Retry-After` after the response body has been closed.
- **Contract narrowed to bounded-body responses.** Doc-comment on `Call` is explicit: streaming or large unbounded bodies should use `client.Do` directly; SSE has its own path. This locks in the existing read-entire-body behavior as an intentional trait.

## Risk / blast radius

- Affects: anyone calling `http.Call`, reading `HTTPError.Message`, or relying on `InsecureSkipVerify: true` baked into the default clients. All three need updates.
- Tests covering this: 12 new tests in `http/caller_test.go`. Full suite green incl. `-race`.
- Pressure-test:
  - Callers that hit internal self-signed endpoints with the default clients — they now need `WithInsecureTLS()` or a custom client. Documented in UPGRADING.md.
  - Code paths reading `HTTPError.Message` directly — compile error, easy to fix.

## Out of scope (deliberately deferred)

- `WithHeader` / `WithBody` / `WithJSONBody` request-builder options — caller still constructs the `*http.Request` themselves via `NewRequest` / `NewJsonRequest`. Easy follow-up if needed.
- Retry/backoff that consumes `HTTPError.Header.Get("Retry-After")` — a natural next step but not in this PR.
- Replacing the four QPS-tuned clients with an option-builder. They remain as convenience singletons.
